### PR TITLE
Added website URL onto README.md (#38)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # TesseractCoding.github.io
+
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+
 [![All Contributors](https://img.shields.io/badge/all_contributors-7-orange.svg?style=flat-square)](#contributors-)
+
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
-Official Website for Tesseract Coding ❤️
+
+Official Website for [Tesseract Coding](https://www.tesseractcoding.tech/) ❤️
 
 ## Contributors ✨
 
@@ -25,6 +29,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind are welcome!


### PR DESCRIPTION
Hello there, this PR was made to solve this #38 issue which was adding the website's URL onto the `README.md` file which I just did and there is one more thing that is mentioned in the issue which is adding the website's URL onto the repository description box which can only be done by the maintainer.

Kindly check this PR and do let me know if something else is needed.